### PR TITLE
fix price in calculate_discount

### DIFF
--- a/src/include/order/class-wc-retailcrm-order-item.php
+++ b/src/include/order/class-wc-retailcrm-order-item.php
@@ -107,7 +107,7 @@ class WC_Retailcrm_Order_Item extends WC_Retailcrm_Abstracts_Data
         $product_price = max(0, round($item->get_total() ? $item->get_total() / $item->get_quantity() : 0));
         $product_tax  = $item->get_total_tax() ? $item->get_total_tax() / $item->get_quantity() : 0;
         $price_item = $product_price + $product_tax;
-        $discount_price = $price - $price_item;
+        $discount_price = max(0, round($price)) - $price_item;
 
         return $discount_price;
     }


### PR DESCRIPTION
Продолжение фикса с подсчетом скидки, если цена товара дробная и скидки не будет, в расчете возможно получение не нулевого а отрицательного значения скидки, данный фикс исправляет подобный сбой