### PR TITLE
Исправлен баг с некорректной передачей дробного количества

### DIFF
--- a/src/include/order/class-wc-retailcrm-order-item.php
+++ b/src/include/order/class-wc-retailcrm-order-item.php
@@ -23,7 +23,7 @@ class WC_Retailcrm_Order_Item extends WC_Retailcrm_Abstracts_Data
         'offer' => array(),
         'productName' => '',
         'initialPrice' => 0.00,
-        'quantity' => 0
+        'quantity' => 0.0
     );
 
     /**
@@ -53,7 +53,7 @@ class WC_Retailcrm_Order_Item extends WC_Retailcrm_Abstracts_Data
 
         $data['productName'] = $item['name'];
         $data['initialPrice'] = (float)$price;
-        $data['quantity'] = $item['qty'];
+        $data['quantity'] = (double)$item['qty'];
 
         $this->set_data_fields($data);
         $this->set_offer($item);
@@ -126,7 +126,7 @@ class WC_Retailcrm_Order_Item extends WC_Retailcrm_Abstracts_Data
             'offer' => array(),
             'productName' => '',
             'initialPrice' => 0.00,
-            'quantity' => 0
+            'quantity' => 0.0
         );
     }
 }

--- a/src/include/order/class-wc-retailcrm-order-item.php
+++ b/src/include/order/class-wc-retailcrm-order-item.php
@@ -23,7 +23,7 @@ class WC_Retailcrm_Order_Item extends WC_Retailcrm_Abstracts_Data
         'offer' => array(),
         'productName' => '',
         'initialPrice' => 0.00,
-        'quantity' => 0.0
+        'quantity' => 0.00
     );
 
     /**
@@ -126,7 +126,7 @@ class WC_Retailcrm_Order_Item extends WC_Retailcrm_Abstracts_Data
             'offer' => array(),
             'productName' => '',
             'initialPrice' => 0.00,
-            'quantity' => 0.0
+            'quantity' => 0.00
         );
     }
 }


### PR DESCRIPTION
Исправлен баг при котором передавалось нулевое количество товара и соответственно заказ не создавался в retailCRM, т.к. по умолчанию в поле quantity могло содержаться только integer значение.