### PR TITLE
Fix error 'Element 'phpunit', attribute 'syntaxCheck': The attribute …

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,6 @@
     verbose="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="true"
     >
     <testsuites>
         <testsuite name="Retailcrm WooCommerce Test Suite">


### PR DESCRIPTION
…'syntaxCheck' is not allowed'