### PR TITLE
fix bag history

### DIFF
--- a/src/include/class-wc-retailcrm-history.php
+++ b/src/include/class-wc-retailcrm-history.php
@@ -563,14 +563,6 @@ if ( ! class_exists( 'WC_Retailcrm_History' ) ) :
                 return false;
             }
 
-            if (is_array($this->order_methods)
-                && $this->order_methods
-                && isset($order['orderMethod'])
-                && !in_array($order['orderMethod'], $this->order_methods)
-            ) {
-                return false;
-            }
-
             $orderResponse = $this->retailcrm->ordersGet($order['id'], 'id');
 
             if (null !== $orderResponse && $orderResponse->offsetExists('order')) {


### PR DESCRIPTION
Добрый день, обнаружил ошибку при выгрузке истории из CRM в woocommerce. 
Данный фильтр отрабатывает не корректно, а именно всегда возвращает **false.**
 

>  if (is_array($this->order_methods) // возвращает true, исходя из структуры
>                 && $this->order_methods  // возвращает true
>                 && isset($order['orderMethod']) // возвращает true, даже если массив пуст.
>                 && !in_array($order['orderMethod'], $this->order_methods)) // возвращает true, если order['orderMethod'] - пустое.
> {return false;}

Т.о. история не приходит в CMS. Есть ли необходимость в данном фильтре, именно тут? Я полагаю, проверка излишняя.  Если есть такая необходимость, то необходимо пересмотреть логику работы данного фильтра. Т.к. сейчас история фактически не выгружается.