### PR TITLE
Add filters into class-wc-retailcrm-order-address.php

### DIFF
--- a/src/include/order/class-wc-retailcrm-order-address.php
+++ b/src/include/order/class-wc-retailcrm-order-address.php
@@ -14,14 +14,16 @@ class WC_Retailcrm_Order_Address extends WC_Retailcrm_Abstracts_Address
     /** @var string $filter_name */
     protected $filter_name = 'order_address';
 
-    /**
-     * @param WC_Order $order
-     *
-     * @return self
-     */
-    public function build($order)
-    {
-        $address = $this->getOrderAddress($order);
+	/**
+	 * @param WC_Order $order
+	 *
+	 * @return self
+	 */
+	public function build( $order )
+	{
+		$address = $order->get_address($this->address_type);
+
+		$address = apply_filters( 'wc_retail_crm_order_address', $address, $order, $this->address_type );
 
         if (!empty($address)) {
             $data = array(
@@ -33,14 +35,18 @@ class WC_Retailcrm_Order_Address extends WC_Retailcrm_Abstracts_Address
             $this->set_data_fields($data);
         }
 
-        $this->set_data_field('text', sprintf(
-            "%s %s %s %s %s",
-            $address['postcode'],
-            $address['state'],
-            $address['city'],
-            $address['address_1'],
-            $address['address_2']
-        ));
+		$formatted = sprintf(
+			"%s %s %s %s %s",
+			$address['postcode'],
+			$address['state'],
+			$address['city'],
+			$address['address_1'],
+			$address['address_2']
+		);
+
+		$formatted = apply_filters( 'wc_retail_crm_formatted_address', $formatted, $address );
+
+		$this->set_data_field( 'text', $formatted );
 
         return $this;
     }


### PR DESCRIPTION
Здравствуйте. 

В процессе работы с плагином RetailCRM для WordPress мы столкнулись с необходимостью формировать строку адреса доставки товара по своему алгоритму. Для этого мы модифицировали класс class-wc-retailcrm-order-address.php (предварительно создав его копию в папке wp-content/retailcrm-custom). 

Кроме того мы заметили одну особенность работы класса class-wc-retailcrm-abstracts-address.php, которая нам не понравилась. Метод validateAddress проверяет правильность адреса, введенного пользователем и в случае отсутствия некоторых полей использует адрес из аккаунта пользователя. Но у нас на сайте предусмотрена возможность совершать покупки без регистрации. И в этом случае, если пользователь, скажем, не заполнил поле индекса (что не критично), метод попытается взять данные адреса из аккаунта пользователя. А поскольку аккаунт отсутствует, то поле адреса вообще окажется пустым. 

Обе этих проблемы ( (1)формирование поля адреса по собственным правилам и (2) возможность не потерять адрес для заказов от незарегистрированных пользователей) мы решили добавив фильтры в метод build класса class-wc-retailcrm-order-address.php. 

Мы подумали, что другим пользователям тоже может быть полезен этот опыт и предлагаем вам в новых версиях плагина использовать фильтры для массива адреса и для текстового поля адреса, которые используются в методе build класса class-wc-retailcrm-order-address.php.