### PR TITLE
Fix upload inventories

### DIFF
--- a/src/include/class-wc-retailcrm-inventories.php
+++ b/src/include/class-wc-retailcrm-inventories.php
@@ -71,8 +71,7 @@ if (!class_exists('WC_Retailcrm_Inventories')) :
                         $product = retailcrm_get_wc_product($offer[$this->bind_field], $this->retailcrm_settings);
 
                         if ($product instanceof WC_Product) {
-                            if ($product->get_type() == 'variation' || $product->get_type() == 'variable') {
-                                $parentId = $product->get_parent_id();
+                            if (($product->get_type() == 'variation' || $product->get_type() == 'variable') && $parentId = $product->get_parent_id()) {
 
                                 if (isset($variationProducts[$parentId])) {
                                     $variationProducts[$parentId] += $offer['quantity'];


### PR DESCRIPTION
Обнаружен баг с выгрузкой остатков. Если был найден товар, у которого не задан parent_id, то метод возвращает 0, и модуль в итоге пытается выгрузить остатки по товару с id равным 0 и падает с 500ой при попытке получения товара с id=0. Добавлена проверка на наличие parent_id.