### PR TITLE
Fixed spanish accents processing in ICML

### DIFF
--- a/src/include/class-wc-retailcrm-icml.php
+++ b/src/include/class-wc-retailcrm-icml.php
@@ -119,7 +119,7 @@ if (!class_exists('WC_Retailcrm_Icml')) :
             $string = sprintf(
                 '<?xml version="1.0" encoding="UTF-8"?><yml_catalog date="%s"><shop><name>%s</name><categories/><offers/></shop></yml_catalog>',
                 current_time('Y-m-d H:i:s'),
-                $this->shop
+                html_entity_decode($this->shop)
             );
 
             file_put_contents($this->tmpFile, $string, LOCK_EX);


### PR DESCRIPTION
Генерация ICML падала, когда в названии магазина использовались символы á í и т. д.